### PR TITLE
Add support of settings property placeholders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,11 +70,22 @@
       <artifactId>maven-shared-utils</artifactId>
       <version>3.2.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-interpolation</artifactId>
+      <version>1.25</version>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>1.19.0</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   </parent>
 
   <artifactId>maven-verifier</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>1.7.0-SNAPSHOT</version>
 
   <name>Apache Maven Verifier Component</name>
   <description>Provides a test harness for Maven integration tests.</description>

--- a/src/main/java/org/apache/maven/shared/verifier/Verifier.java
+++ b/src/main/java/org/apache/maven/shared/verifier/Verifier.java
@@ -334,20 +334,10 @@ public class Verifier
     {
         Properties properties = new Properties();
 
-        try
+        File propertiesFile = new File( getBasedir(), filename );
+        try ( FileInputStream fis = new FileInputStream( propertiesFile ) ) 
         {
-            File propertiesFile = new File( getBasedir(), filename );
-            if ( propertiesFile.exists() )
-            {
-                try ( FileInputStream fis = new FileInputStream( propertiesFile ) ) 
-                {
-                    properties.load( fis );
-                }
-            }
-        }
-        catch ( FileNotFoundException e )
-        {
-            throw new VerificationException( "Error reading properties file", e );
+            properties.load( fis );
         }
         catch ( IOException e )
         {

--- a/src/test/java/org/apache/maven/shared/verifier/VerifierLocalRepositoryTest.java
+++ b/src/test/java/org/apache/maven/shared/verifier/VerifierLocalRepositoryTest.java
@@ -1,0 +1,214 @@
+package org.apache.maven.shared.verifier;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+
+import org.apache.maven.shared.utils.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class VerifierLocalRepositoryTest
+{
+    private static File testDirectory;
+    private static File settingsFile;
+
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+    @Rule
+    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+    @BeforeClass
+    public static void createTestDirectory() throws IOException
+    {
+        Class<?> thisClass = VerifierLocalRepositoryTest.class;
+        String testDirectoryParent = thisClass.getProtectionDomain().getCodeSource().getLocation().getPath();
+        testDirectory = new File( testDirectoryParent, thisClass.getSimpleName() + ".tmp" );
+        assertTrue( testDirectory.mkdir() );
+        settingsFile = new File( testDirectory, "settings.xml" );
+        assertTrue( settingsFile.createNewFile() );
+    }
+
+    @Before
+    public void clearDefaultProperties() {
+        System.clearProperty( "maven.repo.local" );
+        System.clearProperty( "user.home" );
+    }
+
+    private static void fillSettingsFile( String content ) throws FileNotFoundException
+    {
+        try ( PrintStream stream = new PrintStream( new FileOutputStream( settingsFile ) ) )
+        {
+            stream.println( content );
+        }
+    }
+
+    @AfterClass
+    public static void deleteTestDirectory() throws IOException
+    {
+        FileUtils.deleteDirectory( testDirectory );
+        testDirectory = null;
+        settingsFile = null;
+    }
+
+    @Test( expected = VerificationException.class )
+    public void testNotSetUserHomeAbsent() throws VerificationException, IOException
+    {
+        fillSettingsFile( "<settings></settings>" );
+        new Verifier( testDirectory.getPath(), settingsFile.getAbsolutePath() );
+    }
+
+    @Test
+    public void testNotSet() throws VerificationException, IOException
+    {
+        File userHome = new File( testDirectory, "defaultUserHome" );
+        System.setProperty( "user.home", userHome.getPath() );
+        fillSettingsFile( "<settings></settings>" );
+        Verifier verifier = new Verifier( testDirectory.getPath(), settingsFile.getAbsolutePath() );
+        assertEquals( new File( userHome, ".m2/repository" ).getPath(), verifier.getLocalRepository() );
+    }
+
+    @Test
+    public void testSetByProperty() throws VerificationException, IOException
+    {
+        String repositoryPath = new File( testDirectory, "propertyRepository" ).getPath();
+        System.setProperty( "maven.repo.local", repositoryPath );
+        fillSettingsFile( "<settings></settings>" );
+        Verifier verifier = new Verifier( testDirectory.getPath(), settingsFile.getAbsolutePath() );
+        assertEquals( repositoryPath, verifier.getLocalRepository() );
+    }
+
+    @Test
+    public void testNoPlaceholders() throws VerificationException, IOException
+    {
+        String repositoryPath = new File( testDirectory, "noPlaceholdersRepository" ).getPath();
+        fillSettingsFile( "<settings>\n" +
+            "  <localRepository>" + repositoryPath + "</localRepository>\n" +
+            "</settings>" );
+        Verifier verifier = new Verifier( testDirectory.getPath(), settingsFile.getAbsolutePath() );
+        assertEquals( repositoryPath, verifier.getLocalRepository() );
+    }
+
+    @Test
+    public void testEnvPlaceholder() throws VerificationException, IOException
+    {
+        String repositoryPath = new File( testDirectory, "envPlaceholderRepository" ).getPath();
+        environmentVariables.set( "TEST_ENV_VAR", repositoryPath );
+        fillSettingsFile( "<settings>\n" +
+            "  <localRepository>${env.TEST_ENV_VAR}</localRepository>\n" +
+            "</settings>" );
+        Verifier verifier = new Verifier( testDirectory.getPath(), settingsFile.getAbsolutePath() );
+        assertEquals( repositoryPath, verifier.getLocalRepository() );
+    }
+
+    @Test( expected = VerificationException.class )
+    public void testAbsentEnvPlaceholder() throws VerificationException, IOException
+    {
+        environmentVariables.clear( "TEST_ENV_VAR" );
+        fillSettingsFile( "<settings>\n" +
+            "  <localRepository>${env.TEST_ENV_VAR}</localRepository>\n" +
+            "</settings>" );
+        new Verifier( testDirectory.getPath(), settingsFile.getAbsolutePath() );
+    }
+
+    @Test( expected = VerificationException.class )
+    public void testProjectPlaceholder() throws VerificationException, IOException
+    {
+        fillSettingsFile( "<settings>\n" +
+            "  <localRepository>${project.properties.repo}</localRepository>\n" +
+            "</settings>" );
+        new Verifier( testDirectory.getPath(), settingsFile.getAbsolutePath() );
+    }
+
+    @Test
+    @Ignore( "TODO: implement settings placeholder handling" )
+    public void testSettingsPlaceholder() throws VerificationException, IOException
+    {
+        String repositoryPath = new File( testDirectory, "settingsPlaceholderRepository" ).getPath();
+        fillSettingsFile( "<settings>\n" +
+            "  <localRepository>${settings.properties.repo}</localRepository>\n" +
+            "  <properties>\n" +
+            "    <repo>" + repositoryPath + "</repo>\n" +
+            "  </properties>\n" +
+            "</settings>" );
+        Verifier verifier = new Verifier( testDirectory.getPath(), settingsFile.getAbsolutePath() );
+        assertEquals( repositoryPath, verifier.getLocalRepository() );
+    }
+
+    @Test
+    public void testSystemPropertyPlaceholder() throws VerificationException, IOException
+    {
+        String repositoryPath = new File( testDirectory, "systemPropertyPlaceholderRepository" ).getPath();
+        System.setProperty( "test_sys_prop", repositoryPath );
+        fillSettingsFile( "<settings>\n" +
+            "  <localRepository>${test_sys_prop}</localRepository>\n" +
+            "</settings>" );
+        Verifier verifier = new Verifier( testDirectory.getPath(), settingsFile.getAbsolutePath() );
+        assertEquals( repositoryPath, verifier.getLocalRepository() );
+    }
+
+    @Test( expected = VerificationException.class )
+    public void testAbsentSystemPropertyPlaceholder() throws VerificationException, IOException
+    {
+        System.clearProperty( "test_sys_prop" );
+        fillSettingsFile( "<settings>\n" +
+            "  <localRepository>${test_sys_prop}</localRepository>\n" +
+            "</settings>" );
+        new Verifier( testDirectory.getPath(), settingsFile.getAbsolutePath() );
+    }
+
+    @Test
+    public void testCommonValue() throws VerificationException, IOException
+    {
+        File userHome = new File( testDirectory, "userHome" );
+        System.setProperty( "user.home", userHome.getPath() );
+        fillSettingsFile( "<settings>\n" +
+            "  <localRepository>${user.home}/.m2/repository</localRepository>\n" +
+            "</settings>" );
+        Verifier verifier = new Verifier( testDirectory.getPath(), settingsFile.getAbsolutePath() );
+        assertEquals( new File( userHome, ".m2/repository" ).getPath(), verifier.getLocalRepository() );
+    }
+
+    @Test
+    public void testTwoPlaceholders() throws VerificationException, IOException
+    {
+        File repository = new File( testDirectory, "twoPlaceholdersRepository" );
+        System.setProperty( "test_sys_prop_1", repository.getParent() );
+        System.setProperty( "test_sys_prop_2", repository.getName() );
+        fillSettingsFile( "<settings>\n" +
+            "  <localRepository>${test_sys_prop_1}/${test_sys_prop_2}</localRepository>\n" +
+            "</settings>" );
+        Verifier verifier = new Verifier( testDirectory.getPath(), settingsFile.getAbsolutePath() );
+        assertEquals( repository.getPath(), verifier.getLocalRepository() );
+    }
+}

--- a/src/test/java/org/apache/maven/shared/verifier/VerifierTest.java
+++ b/src/test/java/org/apache/maven/shared/verifier/VerifierTest.java
@@ -20,16 +20,20 @@ package org.apache.maven.shared.verifier;
  */
 
 import static org.junit.Assert.assertEquals;
+import static org.hamcrest.CoreMatchers.isA;
 
+import java.io.FileNotFoundException;
 import java.util.Arrays;
 
-import org.apache.maven.shared.verifier.ForkedLauncher;
-import org.apache.maven.shared.verifier.VerificationException;
-import org.apache.maven.shared.verifier.Verifier;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class VerifierTest
 {
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
     private void check( String expected, String... lines )
     {
         assertEquals( expected, ForkedLauncher.extractMavenVersion( Arrays.asList( lines ) ) );
@@ -81,4 +85,14 @@ public class VerifierTest
                       Verifier.stripAnsi( "\u001B[1m--- \u001B[0;32mplugin:version:goal\u001B[0;1m (id)\u001B[m @ "
                           + "\u001B[36martifactId\u001B[0;1m ---\u001B[m" ) );
     }
+
+    @Test
+    public void testLoadPropertiesFNFE() throws VerificationException
+    {
+        exception.expectCause( isA( FileNotFoundException.class) );
+
+        Verifier verifier = new Verifier( "src/test/resources" );
+        verifier.loadProperties( "unknown.properties" );
+    }
+
 }


### PR DESCRIPTION
There are a problem occurs when `<localRepository>` in a _settings.xml_ contains any of placeholders declared [here](https://maven.apache.org/settings.html#Properties): in my case, I could build [pitest](https://github.com/hcoles/pitest/issues), only if I inline `${user.home}`. This pull request fixes it for environment and system properties placeholders.