### PR TITLE
[MSHARED-690] Change package from org.apache.maven.it to o.a.m.shared.verifier

### DIFF
--- a/src/main/java/org/apache/maven/shared/verifier/Embedded3xLauncher.java
+++ b/src/main/java/org/apache/maven/shared/verifier/Embedded3xLauncher.java
@@ -1,4 +1,4 @@
-package org.apache.maven.it;
+package org.apache.maven.shared.verifier;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/src/main/java/org/apache/maven/shared/verifier/ForkedLauncher.java
+++ b/src/main/java/org/apache/maven/shared/verifier/ForkedLauncher.java
@@ -1,4 +1,4 @@
-package org.apache.maven.it;
+package org.apache.maven.shared.verifier;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/src/main/java/org/apache/maven/shared/verifier/LauncherException.java
+++ b/src/main/java/org/apache/maven/shared/verifier/LauncherException.java
@@ -1,4 +1,4 @@
-package org.apache.maven.it;
+package org.apache.maven.shared.verifier;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -20,9 +20,9 @@ package org.apache.maven.it;
  */
 
 /**
- * @author Jason van Zyl
+ * @author Benjamin Bentmann
  */
-public class VerificationException
+class LauncherException
     extends Exception
 {
     /**
@@ -30,22 +30,14 @@ public class VerificationException
      */
     private static final long serialVersionUID = 1L;
 
-    public VerificationException()
-    {
-    }
-
-    public VerificationException( String message )
+    LauncherException( String message )
     {
         super( message );
     }
 
-    public VerificationException( Throwable cause )
-    {
-        super( cause );
-    }
-
-    public VerificationException( String message, Throwable cause )
+    LauncherException( String message, Throwable cause )
     {
         super( message, cause );
     }
+
 }

--- a/src/main/java/org/apache/maven/shared/verifier/MavenLauncher.java
+++ b/src/main/java/org/apache/maven/shared/verifier/MavenLauncher.java
@@ -1,4 +1,4 @@
-package org.apache.maven.it;
+package org.apache.maven.shared.verifier;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/src/main/java/org/apache/maven/shared/verifier/VerificationException.java
+++ b/src/main/java/org/apache/maven/shared/verifier/VerificationException.java
@@ -1,4 +1,4 @@
-package org.apache.maven.it;
+package org.apache.maven.shared.verifier;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -20,9 +20,9 @@ package org.apache.maven.it;
  */
 
 /**
- * @author Benjamin Bentmann
+ * @author Jason van Zyl
  */
-class LauncherException
+public class VerificationException
     extends Exception
 {
     /**
@@ -30,14 +30,22 @@ class LauncherException
      */
     private static final long serialVersionUID = 1L;
 
-    LauncherException( String message )
+    public VerificationException()
+    {
+    }
+
+    public VerificationException( String message )
     {
         super( message );
     }
 
-    LauncherException( String message, Throwable cause )
+    public VerificationException( Throwable cause )
+    {
+        super( cause );
+    }
+
+    public VerificationException( String message, Throwable cause )
     {
         super( message, cause );
     }
-
 }

--- a/src/main/java/org/apache/maven/shared/verifier/Verifier.java
+++ b/src/main/java/org/apache/maven/shared/verifier/Verifier.java
@@ -1,4 +1,4 @@
-package org.apache.maven.it;
+package org.apache.maven.shared.verifier;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/src/main/java/org/apache/maven/shared/verifier/util/ResourceExtractor.java
+++ b/src/main/java/org/apache/maven/shared/verifier/util/ResourceExtractor.java
@@ -1,4 +1,4 @@
-package org.apache.maven.it.util;
+package org.apache.maven.shared.verifier.util;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/src/test/java/org/apache/maven/shared/verifier/Embedded3xLauncherTest.java
+++ b/src/test/java/org/apache/maven/shared/verifier/Embedded3xLauncherTest.java
@@ -1,4 +1,4 @@
-package org.apache.maven.it;
+package org.apache.maven.shared.verifier;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/src/test/java/org/apache/maven/shared/verifier/ForkedLauncherTest.java
+++ b/src/test/java/org/apache/maven/shared/verifier/ForkedLauncherTest.java
@@ -1,4 +1,4 @@
-package org.apache.maven.it;
+package org.apache.maven.shared.verifier;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 

--- a/src/test/java/org/apache/maven/shared/verifier/VerifierTest.java
+++ b/src/test/java/org/apache/maven/shared/verifier/VerifierTest.java
@@ -1,4 +1,4 @@
-package org.apache.maven.it;
+package org.apache.maven.shared.verifier;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one


### PR DESCRIPTION
Followup on https://github.com/apache/maven-verifier/pull/31
The major version has been upgraded, so now is the time to change the package.
If merged, the impact on `maven-integration-testing` is done by https://github.com/apache/maven-integration-testing/pull/191